### PR TITLE
ARWorldTrackingSessionConfiguration deprecated

### DIFF
--- a/arkit-by-example/ViewController.h
+++ b/arkit-by-example/ViewController.h
@@ -36,7 +36,7 @@
 @property (nonatomic, retain) NSMutableDictionary<NSUUID *, Plane *> *planes;
 @property (nonatomic, retain) NSMutableArray<Cube *> *cubes;
 @property (nonatomic, retain) Config *config;
-@property (nonatomic, retain) ARWorldTrackingSessionConfiguration *arConfig;
+@property (nonatomic, retain) ARWorldTrackingConfiguration *arConfig;
 @property (weak, nonatomic) IBOutlet MessageView *messageViewer;
 @property (nonatomic) ARTrackingState currentTrackingState;
 

--- a/arkit-by-example/ViewController.m
+++ b/arkit-by-example/ViewController.m
@@ -30,7 +30,7 @@
   [self setupRecognizers];
   
   // Create a ARSession confi object we can re-use
-  self.arConfig = [ARWorldTrackingSessionConfiguration new];
+  self.arConfig = [ARWorldTrackingConfiguration new];
   self.arConfig.lightEstimationEnabled = YES;
   self.arConfig.planeDetection = ARPlaneDetectionHorizontal;
   


### PR DESCRIPTION
Resolve https://github.com/markdaws/arkit-by-example/issues/7 by replacing deprecated `ARWorldTrackingSessionConfiguration` with `ARWorldTrackingConfiguration`. 