### PR TITLE
Replace deprecated ARKit api calls

### DIFF
--- a/arkit-by-example/ViewController.h
+++ b/arkit-by-example/ViewController.h
@@ -36,7 +36,7 @@
 @property (nonatomic, retain) NSMutableDictionary<NSUUID *, Plane *> *planes;
 @property (nonatomic, retain) NSMutableArray<Cube *> *cubes;
 @property (nonatomic, retain) Config *config;
-@property (nonatomic, retain) ARWorldTrackingSessionConfiguration *arConfig;
+@property (nonatomic, retain) ARWorldTrackingConfiguration *arConfig;
 @property (weak, nonatomic) IBOutlet MessageView *messageViewer;
 @property (nonatomic) ARTrackingState currentTrackingState;
 

--- a/arkit-by-example/ViewController.m
+++ b/arkit-by-example/ViewController.m
@@ -30,7 +30,7 @@
   [self setupRecognizers];
   
   // Create a ARSession confi object we can re-use
-  self.arConfig = [ARWorldTrackingSessionConfiguration new];
+  self.arConfig = [ARWorldTrackingConfiguration new];
   self.arConfig.lightEstimationEnabled = YES;
   self.arConfig.planeDetection = ARPlaneDetectionHorizontal;
   


### PR DESCRIPTION
This PR updates the deprecated api calls for ARKit for Xcode 9. The project as of today (10/28/2017) will not compile with Xcode 9 without this update.

* `ARWorldTrackingSessionConfiguration` has been updated to `ARWorldTrackingConfiguration`.

After this update the project will now compile with Xcode 9.